### PR TITLE
Use past tense in metric names

### DIFF
--- a/src/appHandlers.js
+++ b/src/appHandlers.js
@@ -45,7 +45,7 @@ module.exports = function(component,app) {
    * Set app state to handle the back command
    */
   component.handleBack =function(){
-    app.trackMetric('Go Back');
+    app.trackMetric('Clicked Back');
     var previousRoute = component.state.previousRoute;
     var currentRoute = component.state.routeName;
 
@@ -57,7 +57,7 @@ module.exports = function(component,app) {
   };
 
   component.handleOpenMenu = function() {
-    app.trackMetric('Open Menu');
+    app.trackMetric('Opened Menu');
     // Don't try to render if nothing to show
     if (!component.state.loggedInUser) {
       return;
@@ -66,7 +66,7 @@ module.exports = function(component,app) {
   };
 
   component.handleCloseMenu = function() {
-    app.trackMetric('Close Menu');
+    app.trackMetric('Closed Menu');
     component.setState({showingMenu:false});
   };
 
@@ -116,7 +116,7 @@ module.exports = function(component,app) {
    * @param {Message} mostRecentMessageInThread - The most recent message in a thread
    */
   component.handleShowConversationThread = function(mostRecentMessageInThread){
-    app.trackMetric('Show Note Thread');
+    app.trackMetric('Viewed Note Thread');
     var messagesId = mostRecentMessageInThread.id;
 
     if(mostRecentMessageInThread.parentmessage){
@@ -150,7 +150,7 @@ module.exports = function(component,app) {
    * @param {Object} note - The root message text of this thread
    */
   component.handleStartConversation = function(note){
-    app.trackMetric('Add Note');
+    app.trackMetric('Added Note');
     var message = app.dataHelper.createMessage(
       note.text,
       component.state.loggedInUser,
@@ -177,7 +177,7 @@ module.exports = function(component,app) {
    * @param {Object} note - A comment on the thread
    */
   component.handleAddingToConversation = function(note){
-    app.trackMetric('Add Comment');
+    app.trackMetric('Added Comment');
     var thread = component.state.selectedThread;
     var parentId = app.dataHelper.getParentMessageId(thread);
 


### PR DESCRIPTION
@jh-bate @kentquirk A small tweak in metric naming, if you guys are ok with it, I think it would be nice to be consistent and use the "start with verb in past tense"-convention that I used in Blip to name these events?

So the list in Clamshell now looks like:
- Logged In
- Logged Out
- Opened Menu
- Closed Menu
- Changed Selected User
- Viewed Note Thread
- Added Note
- Added Comment
