### PR TITLE
add margin for date and time editing inputs

### DIFF
--- a/src/components/form/MessageForm.js
+++ b/src/components/form/MessageForm.js
@@ -229,17 +229,17 @@ var MessageForm = React.createClass({
       /* jshint ignore:start */
       <div ref='editDateTime'>
         <input
-          type='date'
-          ref='editMessageDate'
-          value={this.state.date}
-          className='messageform-date'
-          onChange={this.handleDateChange}/>
-        <input
           type='time'
           ref='editMessageTime'
           value={this.state.time}
           className='messageform-time'
           onChange={this.handleTimeChange}/>
+        <input
+          type='date'
+          ref='editMessageDate'
+          value={this.state.date}
+          className='messageform-date'
+          onChange={this.handleDateChange}/>
       </div>
       /* jshint ignore:end */
     );

--- a/src/components/form/MessageForm.less
+++ b/src/components/form/MessageForm.less
@@ -56,14 +56,13 @@ a.messageform-change-datetime {
 
 .messageform-date {
   &:extend(.form-control all);
-  display: inline;
-  width: 60%;
+  margin-bottom: @message-form-spacing-unit;
 }
 
 .messageform-time {
   &:extend(.form-control all);
-  display: inline;
-  width: 40%;
+  margin-top: @message-form-spacing-unit;
+  margin-bottom: @message-form-spacing-unit;
 }
 
 .messageform-button {


### PR DESCRIPTION
based on what had been done in nutshell I have updated this so the
inputs are on a separate line - it seems maybe in iOS extra padding was
added that screwed up the rendering
